### PR TITLE
Add Nix package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 *Sexy package managers for your OS X, Linux & Windows CLIs.*
 
 * Universal
+	* [nix](http://nixos.org/nix/) - Nix is a cross platform (Linux and MacOS) package manager that supports both from-source and pre-built binary distribution, reproducible development environments, multiple versions of the same package installed simultaneously (no more conflicts!), and much more.
 	* [pip](http://www.pip-installer.org/) - pip is a package management system used to install and manage software packages written in Python.
 	* [easyinstall](http://pypi.python.org/pypi/setuptools) - Easily download, build, install, upgrade, and uninstall Python packages.
 	* [npmjs](http://npmjs.com/) - npm is the package manager for JavaScript.


### PR DESCRIPTION
Nix is a pretty sweet package manager that runs on both Linux and MacOS. You can easily create self-contained, reproducible development environments (think Docker, but less heavyweight). It also has an extensive set of binary packages for most popular languages (C/C++, Python, C#, Haskell, Erlang, Elm, etc). As opposed to, say, Homebrew, Nix packages are fully, 100% deterministic, so if you've ever wasted time on cryptic runtime errors due to e.g. upgrading OpenSSL and having the ABI change out from under you (thus breaking everything else you had previously installed), Nix completely avoids that.

I figure with the time it's saved me, it would be a sin not to share the productivity boost with everyone else.