### PR TITLE
Add TotalTerminal OS X extension by BinaryAge

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [ZOC](https://www.emtec.com/zoc/index.html) - SSH/Telnet Client and Terminal Emulator for macOS and Windows.
 * [Black Screen](https://github.com/vshatskyi/black-screen) - A terminal emulator for the 21st century.
 * [DTerm](http://decimus.net/DTerm) - A command line anywhere and everywhere.
+* [TotalTerminal](https://totalterminal.binaryage.com/) - A system-wide terminal available on a hot-key.
 * [Go2Shell](http://zipzapmac.com/Go2Shell) - Opens a terminal window to the current directory in Finder.
 * [Cathode](http://www.secretgeometry.com/apps/cathode/) - A vintage terminal for macOS.
 * [Alacritty](https://github.com/jwilm/alacritty) - A cross-platform, GPU-accelerated terminal emulator.


### PR DESCRIPTION
https://totalterminal.binaryage.com/

It's a terminal plugin to enable quake-style dropdown terminals anywhere on OS X, similar to iTerm2's but more lightweight.