### PR TITLE
Add Mosh (Mobile Shell)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [Cmder](https://github.com/cmderdev/cmder) - Lovely console emulator package for Windows.
 * [Terminix](https://gnunn1.github.io/terminix-web/) - An advanced GTK3 tiling terminal emulator.
 * [ConsoleZ](https://github.com/cbucher/console) - ConsoleZ is a Windows console window enhancement. It is a fork of [Console](http://sourceforge.net/projects/console) project. 
+* [Mosh](https://github.com/mobile-shell/mosh) - Remote terminal application that allows roaming, supports intermittent connectivity, and provides intelligent local echo and line editing of user keystrokes.
 ## Package Managers
 
 *Sexy package managers for your OS X, Linux & Windows CLIs.*

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [Cmder](https://github.com/cmderdev/cmder) - Lovely console emulator package for Windows.
 * [Terminix](https://gnunn1.github.io/terminix-web/) - An advanced GTK3 tiling terminal emulator.
 * [ConsoleZ](https://github.com/cbucher/console) - ConsoleZ is a Windows console window enhancement. It is a fork of [Console](http://sourceforge.net/projects/console) project. 
-* [Mosh](https://github.com/mobile-shell/mosh) - Remote terminal application that allows roaming, supports intermittent connectivity, and provides intelligent local echo and line editing of user keystrokes.
+* [Mosh](https://github.com/mobile-shell/mosh) - Remote terminal application that allows roaming and supports intermittent connectivity.
 
 ## Package Managers
 


### PR DESCRIPTION
Added Mosh to Terminal Emulation Applications although it doesn't really fit there. It doesn't really fit under any of the current categories. However, it is a very useful tool for anyone who constantly moves from wifi hotspot to wifi hotspot and doesn't want to have to reconnect to ssh each time - it stays connected.