### PR TITLE
Adds colorls

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [exa](https://github.com/ogham/exa) - Replacement for 'ls' written in Rust.
 * [homebrew-cask](https://github.com/caskroom/homebrew-cask) - CLI workflow for the administration of macOS applications distributed as binaries.
 * [mps-youtube](https://github.com/mps-youtube/mps-youtube) - Terminal based YouTube player and downloader
+* [colorls](https://github.com/athityakumar/colorls) - Beautify the terminal's `ls` command, with color and font-awesome icons.
 
 ## Communication
 


### PR DESCRIPTION
## Checklist for submitting a pull request to `Terminals Are Sexy`:

- [x] I have carefully **read and comply** with the [Contributing Guidelines](https://github.com/k4m4/terminals-are-sexy/blob/master/CONTRIBUTING.md) of this repo.
- [x] I have **searched** the [PRs](https://github.com/k4m4/movies-for-hackers/pulls) of this repo and believe that this is not a duplicate.

- **Title**: colorls
- **Link**: Beautify the terminal's `ls` command, with color and font-awesome icons.
- **Category**: Tools & plugins
- **Description**: Colorls is a Ruby gem that adds a `lc` command on installation. `lc` functions like `ls`, but with colors and font-awesome icons. `lc` is also slowly getting support for all flags like `ls`. 😄 