### PR TITLE
Remove Bower package manager

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,6 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
     * [nix](http://nixos.org/nix/) - Powerful package manager for Linux and other Unix systems that makes package management reliable and reproducible.
     * [pip](https://pip.pypa.io/) - Package management system used to install and manage software packages written in Python.
     * [npmjs](https://www.npmjs.com/) - Package manager for JavaScript.
-    * [bower](https://bower.io/) - Package manager for the web.
     * [duo](https://github.com/duojs/duo) - Next-generation package manager for the front-end.
     * [basher](https://github.com/basherpm/basher) - Package manager for shell scripts.
     * [bpkg](http://www.bpkg.sh/) - JavaScript has npm, Ruby has Gems, Python has pip and now Shell has bpkg.


### PR DESCRIPTION
From the Bower website:
...psst! While Bower is maintained, we recommend using Yarn and Webpack for front-end projects read how to migrate!

Yarn is already part of the list and Webpack doesn't seem to fit into the list. And because awesome lists are primarily for people looking for current information, deprecated content is probably not what we want.

<!--
  Hi there! Thank you for sumbiting a PR!

  Before submitting, let's make sure of a few things.
  Please ensure the following boxes are ticked if they apply.
  If they do not, please try and fulfill them first.
-->

<!-- Checked checkbox should look like this: [x] -->

## Checklist for submitting a pull request to `Terminals Are Sexy`:

- [x] I have carefully **read and comply** with the [Contributing Guidelines](https://github.com/k4m4/terminals-are-sexy/blob/master/CONTRIBUTING.md) of this repo.
- [x] I have **searched** the [PRs](https://github.com/k4m4/terminals-are-sexy/pulls) of this repo and believe that this is not a duplicate.

<!-- 
  Once all boxes are ticked, it would be very helpful if you could fill in the
  following list with the appropriate information. 
--> 

- **Title**: Bower
- **Link**: https://bower.io/
- **Category**: Package managers
- **Description**: Package manager for the web

<!-- Thanks again! 🙌 ❤ -->