### PR TITLE
Add pdd - A tiny date, time diff calculator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -241,6 +241,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [asciinema](https://github.com/asciinema/asciinema) - Terminal session recorder.
 * [rebound](https://github.com/shobrook/rebound) - Command-line debugger that instantly fetches Stack Overflow results when you get a compiler error.
 * [cointop](https://github.com/miguelmota/cointop) - The fastest and most interactive terminal based UI application for tracking cryptocurrencies.
+* [pdd](https://github.com/jarun/pdd) - Tiny date, time diff calculator.
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
#### Description
`pdd` (Python3 Date Diff) is a small cmdline utility to calculate date and time difference.

#### Features
- calculate date difference
- calculate time difference
- calculate diff from *today* and *now*
- add, subtract duration (timeslice) to/from date (time)
- show current date, time and timezone
- minimal dependencies

<!--
  Hi there! Thank you for submitting a PR!

  Before submitting, let's make sure of a few things.
  Please ensure the following boxes are ticked if they apply.
  If they do not, please try and fulfill them first.
-->

<!-- Checked checkbox should look like this: [x] -->

## Checklist for submitting a pull request to `Terminals Are Sexy`:

- [x] I have carefully **read and comply** with the [Contributing Guidelines](https://github.com/k4m4/terminals-are-sexy/blob/master/CONTRIBUTING.md) of this repo.
- [x] I have **searched** the [PRs](https://github.com/k4m4/terminals-are-sexy/pulls) of this repo and believe that this is not a duplicate.

<!-- 
  Once all boxes are ticked, it would be very helpful if you could fill in the
  following list with the appropriate information. 
--> 

- **Title**: pdd
- **Link**: https://github.com/jarun/pdd
- **Category**: Tools and Plugins
- **Description**: A tiny date, time diff calculator

<!-- Thanks again! 🙌 ❤ -->
