### PR TITLE
Add unix-permissions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -247,6 +247,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [tmux](https://tmux.github.io/) - Terminal multiplexer.
 * [tmuxinator](https://github.com/tmuxinator/tmuxinator) - Manage complex tmux sessions easily.
 * [transfer.sh](https://transfer.sh/) - Quickly upload and share files from your shell.
+* [unix-permissions](https://github.com/ehmicky/unix-permissions) - Swiss Army knife for Unix permissions
 * [vifm](https://vifm.info/) - Console file manager with vi key bindings and some ideas from mutt.
 * [wal](https://github.com/dylanaraps/wal) - generate and change colorschemes on the fly.
 * [whereami](https://github.com/rafaelrinaldi/whereami) - Get your geolocation information from the CLI.


### PR DESCRIPTION
Add `unix-permissions`, the Swiss Army knife for Unix permissions.

- [x] I have carefully **read and comply** with the [Contributing Guidelines](https://github.com/k4m4/terminals-are-sexy/blob/master/contributing.md) of this repo.
- [x] I have **searched** the [PRs](https://github.com/k4m4/terminals-are-sexy/pulls) of this repo and believe that this is not a duplicate.

- **Title**: `unix-permissions`
- **Link**: https://github.com/ehmicky/unix-permissions
- **Category**: Tools and Plugins
- **Description**: Swiss Army knife for Unix permissions