### PR TITLE
Remove duo from package managers section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,6 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [basher](https://github.com/basherpm/basher) - Package manager for shell scripts.
 * [bpkg](https://www.bpkg.sh/) - JavaScript has npm, Ruby has Gems, Python has pip and now Shell has bpkg.
 * [composer](https://getcomposer.org) - Composer is a package manager for PHP.
-* [duo](https://github.com/duojs/duo) - Next-generation package manager for the front-end.
 * [guix](https://www.gnu.org/software/guix/) - Functional package manager for installed software packages and versions.
 * [nix](https://nixos.org/nix/) - Powerful package manager for Linux and other Unix systems that makes package management reliable and reproducible.
 * [npmjs](https://www.npmjs.com/) - Package manager for JavaScript.


### PR DESCRIPTION
Hej, duo is deprecated and the GitHub repository is archived.

See: https://github.com/duojs/duo

Cheers, Michael

<!--
  Hi there! Thank you for submitting a PR!

  Before submitting, let's make sure of a few things.
  Please ensure the following boxes are ticked if they apply.
  If they do not, please try and fulfill them first.
-->

<!-- Checked checkbox should look like this: [x] -->

## Checklist for submitting a pull request to `Terminals Are Sexy`:

- [x] I have carefully **read and comply** with the [Contributing Guidelines](https://github.com/k4m4/terminals-are-sexy/blob/master/contributing.md) of this repo.
- [x] I have **searched** the [PRs](https://github.com/k4m4/terminals-are-sexy/pulls) of this repo and believe that this is not a duplicate.

<!-- 
  Once all boxes are ticked, it would be very helpful if you could fill in the
  following list with the appropriate information. 
--> 


<!-- Thanks again! 🙌 ❤ -->
