### PR TITLE
Update Byobu URL/Remove wal and add pywal.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -239,6 +239,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [mps-youtube](https://github.com/mps-youtube/mps-youtube) - Terminal based YouTube player and downloader
 * [neofetch](https://github.com/dylanaraps/neofetch) - Fetches system/theme information in terminal for Linux desktop screenshots. Alternative to screenfetch.
 * [nnn](https://github.com/jarun/nnn) - Tiny, lightning fast, feature-packed file manager.
+* [pywal](https://github.com/dylanaraps/pywal) - generate and change colorschemes on the fly. Successor of wal.
 * [ranger](https://ranger.github.io/) - Console file manager with vi key bindings.
 * [rebound](https://github.com/shobrook/rebound) - Command-line debugger that instantly fetches Stack Overflow results when you get a compiler error.
 * [reddit terminal viewer](https://github.com/michael-lazar/rtv) - Browse Reddit from your terminal.
@@ -254,7 +255,6 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [tmuxinator](https://github.com/tmuxinator/tmuxinator) - Manage complex tmux sessions easily.
 * [transfer.sh](https://transfer.sh/) - Quickly upload and share files from your shell.
 * [vifm](https://vifm.info/) - Console file manager with vi key bindings and some ideas from mutt.
-* [wal](https://github.com/dylanaraps/wal) - generate and change colorschemes on the fly.
 * [whereami](https://github.com/rafaelrinaldi/whereami) - Get your geolocation information from the CLI.
 * [wttr.in](https://github.com/chubin/wttr.in) - The right way to check the weather.
 * [youtube-dl](https://rg3.github.io/youtube-dl/) - download videos from YouTube

--- a/readme.md
+++ b/readme.md
@@ -210,7 +210,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [autojump](https://github.com/wting/autojump) - cd command that learns
 * [bcal](https://github.com/jarun/bcal) - Storage conversion and expression calculator.
 * [buku](https://github.com/jarun/Buku) - command-line bookmark manager.
-* [byobu](http://byobu.co/) - Byobu is an open source text-based window manager and terminal multiplexer.
+* [byobu](https://byobu.org/) - Byobu is an open source text-based window manager and terminal multiplexer.
 * [cointop](https://github.com/miguelmota/cointop) - The fastest and most interactive terminal based UI application for tracking cryptocurrencies.
 * [colorls](https://github.com/athityakumar/colorls) - Beautify the terminal's `ls` command, with color and font-awesome icons.
 * [ddgr](https://github.com/jarun/ddgr) - DuckDuckGo from the terminal.


### PR DESCRIPTION
<!--
  Hi there! Thank you for submitting a PR!

  Before submitting, let's make sure of a few things.
  Please ensure the following boxes are ticked if they apply.
  If they do not, please try and fulfill them first.
-->

<!-- Checked checkbox should look like this: [x] -->

## Checklist for submitting a pull request to `Terminals Are Sexy`:

- [x] I have carefully **read and comply** with the [Contributing Guidelines](https://github.com/k4m4/terminals-are-sexy/blob/master/contributing.md) of this repo.
- [x] I have **searched** the [PRs](https://github.com/k4m4/terminals-are-sexy/pulls) of this repo and believe that this is not a duplicate.

<!-- 
  Once all boxes are ticked, it would be very helpful if you could fill in the
  following list with the appropriate information. 
--> 

- **Title**: Byobu
- **Link**: https://byobu.org/
- **Category**: Tools and Plugins
- **Description**: Byobu is an open source text-based window manager and terminal multiplexer.
---
- **Title**: pywal
- **Link**: https://github.com/dylanaraps/pywal
- **Category**: Tools and Plugins
- **Description**: generate and change colorschemes on the fly. Successor of wal.

<!-- Thanks again! 🙌 ❤ -->

Updating the Byobu URL since I noticed it didn't resolve anymore.
Also noticed wal is depreciated, so I removed it and added its successor pywal.