### PR TITLE
Changed reddit terminal viewer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -248,7 +248,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [nnn](https://github.com/jarun/nnn) - Tiny, lightning fast, feature-packed file manager.
 * [ranger](https://ranger.github.io/) - Console file manager with vi key bindings.
 * [rebound](https://github.com/shobrook/rebound) - Command-line debugger that instantly fetches Stack Overflow results when you get a compiler error.
-* [reddit terminal viewer](https://github.com/michael-lazar/rtv) - Browse Reddit from your terminal.
+* [terminal ui for reddit](https://pypi.org/project/tuir/) - Browse Reddit from your terminal.
 * [ripgrep](https://github.com/BurntSushi/ripgrep) - Code-searching tool like ack and the_silver_searcher, but faster.
 * [screenfetch](https://github.com/KittyKatt/screenFetch) - Fetches system/theme information in terminal for Linux desktop screenshots.
 * [shell2http](https://github.com/msoap/shell2http) - HTTP-server to execute shell commands. Designed for development, prototyping or remote control.


### PR DESCRIPTION
The developer of rtv warned he would stop maintaining the code in june 2019, but the code got forked to tuir.

"RTV development is shutting down": https://github.com/michael-lazar/rtv/issues/696

<!--
  Hi there! Thank you for submitting a PR!

  Before submitting, let's make sure of a few things.
  Please ensure the following boxes are ticked if they apply.
  If they do not, please try and fulfill them first.
-->

<!-- Checked checkbox should look like this: [x] -->

## Checklist for submitting a pull request to `Terminals Are Sexy`:

- [x] I have carefully **read and comply** with the [Contributing Guidelines](https://github.com/k4m4/terminals-are-sexy/blob/master/contributing.md) of this repo.
- [x] I have **searched** the [PRs](https://github.com/k4m4/terminals-are-sexy/pulls) of this repo and believe that this is not a duplicate.

<!-- Thanks again! 🙌 ❤ -->
