### PR TITLE
Remove archived Upterm emulator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,6 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [Termite](https://github.com/thestinger/termite/) - Keyboard-centric terminal, aimed at use within a tiling window manager.
 * [Tilda](https://github.com/lanoxx/tilda) - Gtk based drop down terminal for Linux and Unix.
 * [Tilix](https://gnunn1.github.io/tilix-web/) - Advanced GTK3 tiling terminal emulator that follows the Gnome Human Interface Guidelines.
-* [Upterm](https://github.com/railsware/upterm) - Terminal emulator for the 21st century.
 * [Xfce Terminal](https://docs.xfce.org/apps/terminal/start) - Modern terminal emulator primarily for the Xfce desktop environment.
 * [xterm](https://invisible-island.net/xterm/) - Terminal emulator for the X Window System.
 * [ZOC](https://www.emtec.com/zoc/index.html) - SSH/Telnet Client and Terminal Emulator for macOS and Windows.


### PR DESCRIPTION
<!--
  Hi there! Thank you for submitting a PR!

  Before submitting, let's make sure of a few things.
  Please ensure the following boxes are ticked if they apply.
  If they do not, please try and fulfill them first.
-->

<!-- Checked checkbox should look like this: [x] -->

## Checklist for submitting a pull request to `Terminals Are Sexy`:

- [x] I have carefully **read and comply** with the [Contributing Guidelines](https://github.com/k4m4/terminals-are-sexy/blob/master/contributing.md) of this repo.
- [x] I have **searched** the [PRs](https://github.com/k4m4/terminals-are-sexy/pulls) of this repo and believe that this is not a duplicate.

There is another PR from 2018 that removes Upterm. That one isn't merged as PR owner hasn't reacted to feedback. Thats why opened this one as a replacement PR

<!-- 
  Once all boxes are ticked, it would be very helpful if you could fill in the
  following list with the appropriate information. 
--> 

- **Title**: Upterm
- **Link**: https://github.com/railsware/upterm
- **Category**: Terminal emulator