### PR TITLE
added Standard Unix Notes, a GPG encrypted notes/notebook manager

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -246,6 +246,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [navi](https://github.com/denisidoro/navi) - An interactive cheatsheet tool for the command-line.
 * [neofetch](https://github.com/dylanaraps/neofetch) - Fetches system/theme information in terminal for Linux desktop screenshots. Alternative to screenfetch.
 * [nnn](https://github.com/jarun/nnn) - Tiny, lightning fast, feature-packed file manager.
+* [notes](https://github.com/Standard-Unix-Notes/unix-notes) - GPG Encrypted Notes/Notebook manag    er for Unix/Linux
 * [ranger](https://ranger.github.io/) - Console file manager with vi key bindings.
 * [rebound](https://github.com/shobrook/rebound) - Command-line debugger that instantly fetches Stack Overflow results when you get a compiler error.
 * [reddit terminal viewer](https://github.com/michael-lazar/rtv) - Browse Reddit from your terminal.


### PR DESCRIPTION
 Hi
   
 I've suggested Standard Unix Notes - a GPG encrypted ntoes/notebook manager that runs in any Unix/BSD/Linux etc that supports GnuPG.
   
  It is written in the Bourne shell avoiding Bash as that is not installed by default on some machines.

<!--
  Hi there! Thank you for submitting a PR!

  Before submitting, let's make sure of a few things.
  Please ensure the following boxes are ticked if they apply.
  If they do not, please try and fulfill them first.
-->

<!-- Checked checkbox should look like this: [x] -->

## Checklist for submitting a pull request to `Terminals Are Sexy`:

- [x] I have carefully **read and comply** with the [Contributing Guidelines](https://github.com/k4m4/terminals-are-sexy/blob/master/contributing.md) of this repo.
- [x] I have **searched** the [PRs](https://github.com/k4m4/terminals-are-sexy/pulls) of this repo and believe that this is not a duplicate.

<!-- 
  Once all boxes are ticked, it would be very helpful if you could fill in the
  following list with the appropriate information. 
--> 

- **Title**: Standard(?) Unix Notes
- **Link**: https://github.com/Standard-Unix-Notes/unix-notes
- **Category**:  Tools and Plugins
- **Description**: GnuPG encrypted Notes system ala 'Password Store'

<!-- Thanks again! 🙌 ❤ -->
