### PR TITLE
Update the URL for linuxbrew

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -165,7 +165,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 
 ### Linux
 
-* [linuxbrew](https://linuxbrew.sh/) - The Homebrew package manager for Linux.
+* [linuxbrew](https://docs.brew.sh/Homebrew-on-Linux) - The Homebrew package manager for Linux.
 * [pkgin](http://pkgin.net/) - Aimed at being an apt / yum like tool for managing pkgsrc binary packages.
 
 ### ChromeOS


### PR DESCRIPTION
<!--
  Hi there! Thank you for submitting a PR!

  Before submitting, let's make sure of a few things.
  Please ensure the following boxes are ticked if they apply.
  If they do not, please try and fulfill them first.
-->

<!-- Checked checkbox should look like this: [x] -->

## Checklist for submitting a pull request to `Terminals Are Sexy`:

- [x] I have carefully **read and comply** with the [Contributing Guidelines](https://github.com/k4m4/terminals-are-sexy/blob/master/contributing.md) of this repo.
- [x] I have **searched** the [PRs](https://github.com/k4m4/terminals-are-sexy/pulls) of this repo and believe that this is not a duplicate.

<!-- 
  Once all boxes are ticked, it would be very helpful if you could fill in the
  following list with the appropriate information. 
--> 

- **Title**: Linuxbrew
- **Link**: https://docs.brew.sh/Homebrew-on-Linux
- **Category**: Linux package manager
- **Description**: The Homebrew package manager for Linux.

The linuxbrew entry currently links to a domain that appears to be parked. This changes the URL to the documentation page for installing Homebrew on a Linux machine.

<!-- Thanks again! 🙌 ❤ -->
