### PR TITLE
Fix PuTTY link , Add AbsoluteTelnetSSH

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,6 +112,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 
 *Sexy 3rd party terminal emulation applications.*
 
+* [AbsoluteTelnetSSH](https://www.celestialsoftware.net) - SSH and telnet client for Windows.  Supports smartcards and advanced authentication
 * [Alacritty](https://github.com/jwilm/alacritty) - Cross-platform, GPU-accelerated terminal emulator.
 * [Cmder](https://github.com/cmderdev/cmder) - Lovely console emulator package for Windows.
 * [ConEmu](https://github.com/Maximus5/ConEmu) - Customizable Windows terminal with tabs, splits, quake-style and more.
@@ -126,7 +127,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 * [Konsole](https://konsole.kde.org/) - Terminal emulator for the K Desktop Environment.
 * [MacTerm](https://www.macterm.net/) - Powerful replacement for macOS Terminal.
 * [Mosh](https://github.com/mobile-shell/mosh) - Remote terminal application that allows roaming and supports intermittent connectivity.
-* [PuTTY](https://www.putty.org/) - SSH and telnet client, developed originally by Simon Tatham for the Windows platform.
+* [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty) - SSH and telnet client, developed originally by Simon Tatham for the Windows platform.
 * [Terminator](https://github.com/gnome-terminator/terminator) - Multiple GNOME terminals in one window.
 * [Terminology](https://github.com/billiob/terminology) - The best terminal emulator based on the Enlightenment Foundation Libraries.
 * [Terminus](https://github.com/Eugeny/terminus) - Cross-platform terminal for a more modern age, based on web technologies.


### PR DESCRIPTION
Updated the PuTTY link to the official site.
Add AbsoluteTelnetSSH

<!--
  Hi there! Thank you for submitting a PR!

  Before submitting, let's make sure of a few things.
  Please ensure the following boxes are ticked if they apply.
  If they do not, please try and fulfill them first.
-->

<!-- Checked checkbox should look like this: [x] -->

## Checklist for submitting a pull request to `Terminals Are Sexy`:

- [x] I have carefully **read and comply** with the [Contributing Guidelines](https://github.com/k4m4/terminals-are-sexy/blob/master/contributing.md) of this repo.
- [x] I have **searched** the [PRs](https://github.com/k4m4/terminals-are-sexy/pulls) of this repo and believe that this is not a duplicate.

<!-- 
  Once all boxes are ticked, it would be very helpful if you could fill in the
  following list with the appropriate information. 
--> 

- **Title**: AbsoluteTelnetSSH
- **Link**: https://www.celestialsoftware.net
- **Category**: SSH Client
- **Description**: AbsoluteTelnet/SSH is an SSH client for windows that includes smartcard authentication, post quantum key exchange, and all of the modern SSH protocols needed in today's hostile environments.  In addition, it supports multiple terminal types and advanced terminal based applications such as claude code and neovim.

<!-- Thanks again! 🙌 ❤ -->
