### PR TITLE
Add ccline - type natural language at zsh prompt, get AI answer, run commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ Check out my [blog](https://nikolaskama.me/) and follow me on [Twitter](https://
 ### ZSH
 
 * [alf](https://github.com/psyrendust/alf) - Out of this world super fast and configurable framework for zsh.
+* [ccline](https://github.com/jianshuo/ccline) - Type a thought at your zsh prompt — no command, no prefix — get an AI answer (Claude/Codex) and run any suggested commands from an interactive menu.
 * [ant-zsh](https://github.com/anthraxx/ant-zsh) - Tiny and lightweight ZSH configuration environment for special customization needs.
 * [antibody](https://github.com/getantibody/antibody) - Faster and simpler antigen written in Golang.
 * [antigen](https://github.com/zsh-users/antigen) - Plugin manager for zsh, inspired by oh-my-zsh and vundle.


### PR DESCRIPTION
## What does this add?

[ccline](https://github.com/jianshuo/ccline) — a zsh plugin that hijacks `command_not_found_handler`. Type a natural-language thought at your prompt and get an answer from Claude or Codex. If the answer contains runnable shell commands, an arrow-key menu lets you confirm and run them in the live shell.

```
$ how do I find files bigger than 100MB here

    find . -maxdepth 1 -type f -size +100M

Commands found — ↑/↓ to choose, Enter to run, q to cancel:
 ❯ find . -maxdepth 1 -type f -size +100M
   ➤ Run all of them
   ✗ Cancel
```

Added under **ZSH** as it's a zsh-specific tool.

- Open source (MIT), free
- Zero dependencies beyond zsh + claude/codex CLI
- One-word inputs (typos) still behave normally — no accidental API calls